### PR TITLE
X-RateLimit-Reset is not guaranteed in the response header; see the f…

### DIFF
--- a/foursquare/__init__.py
+++ b/foursquare/__init__.py
@@ -287,7 +287,7 @@ class Foursquare(object):
             result = _get(url, headers=headers, params=params, timeout=self.get_timeout)
             self.rate_limit = result["headers"]["X-RateLimit-Limit"]
             self.rate_remaining = result["headers"]["X-RateLimit-Remaining"]
-            self.rate_reset = result["headers"]["X-RateLimit-Reset"]
+            self.rate_reset = result["headers"].get("X-RateLimit-Reset")
             return result["data"]["response"]
 
         def add_multi_request(self, path, params={}):
@@ -314,7 +314,7 @@ class Foursquare(object):
             )
             self.rate_limit = result["headers"]["X-RateLimit-Limit"]
             self.rate_remaining = result["headers"]["X-RateLimit-Remaining"]
-            self.rate_reset = result["headers"]["X-RateLimit-Reset"]
+            self.rate_reset = result["headers"].get("X-RateLimit-Reset")
             return result["data"]["response"]
 
         def _enrich_params(self, params):


### PR DESCRIPTION
…ollowing excerpt from the [Foursquare docs](https://developer.foursquare.com/docs/places-api/rate-limits/):

"*If you are currently over limits*, our API will return a 403 error, and the response object returned by our API will be empty. We will also include a `X-RateLimit-Reset` header in the response, which is a timestamp that corresponds to when your rate limits will reset." (emphasis added)